### PR TITLE
More search parameters. README and docstrings update.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,4 @@
-* kwallet-auth-source
+* auth-source-kwallet
 
   [[https://melpa.org/#/auth-source-kwallet][file:https://melpa.org/packages/auth-source-kwallet-badge.svg]]
   [[https://melpa.org/#/auth-source-kwallet][file:https://stable.melpa.org/packages/auth-source-kwallet-badge.svg]]
@@ -11,24 +11,24 @@
    If you are using [[https://github.com/jwiegley/use-package][use-package]], you may install the package using with the following code:
 
    #+BEGIN_SRC elisp
-     (use-package kwallet-auth-source
+     (use-package auth-source-kwallet
        :config
-       (kwallet-auth-source-enable))
+       (auth-source-kwallet-enable))
    #+END_SRC
 
-   To enable the auth source, use ~(kwallet-auth-source-enable)~, like in the example above with use-package.
+   To enable the auth source, use ~(auth-source-kwallet-enable)~, like in the example above with use-package.
 
 ** Configuration
 
    The following parameters can be customized:
 
-   - ~kwallet-auth-source-wallet~ :: Default value: "Passwords"
+   - ~auth-source-kwallet-wallet~ :: Default value: "Passwords"
 
      The wallet to use.
-   - ~kwallet-auth-source-folder~ :: Default value: "Passwords"
+   - ~auth-source-kwallet-folder~ :: Default value: "Passwords"
 
      The folder to use in the wallet.
-   - ~kwallet-auth-source-key-separator~ :: Default value: "@"
+   - ~auth-source-kwallet-key-separator~ :: Default value: "@"
 
      The value used to separate the name and the host when looking up
      the key key in the wallet.

--- a/README.org
+++ b/README.org
@@ -27,6 +27,12 @@ To query the secret of "ada@example.com" using the default wallet and folder:
   (auth-source-search :user "ada" :host "example.com" :type 'kwallet)
 #+end_src
 
+Also, user and hostname can be expressed as a label:
+
+#+begin_src elisp
+  (auth-source-search :label "ada@example.com" :type 'kwallet)
+#+end_src
+
 To use a different wallet and folder than the default one:
 
 #+begin_src elisp
@@ -56,6 +62,18 @@ Also, Network Managent secrets can be stored on kwallet and retrieved with auth-
   (auth-source-search :label "{0aeca2dd-549f-4095-9001-96dd52d50813};802-11-wireless-security"
                       :folder "Network Management"
                       :type 'kwallet)
+#+end_src
+
+Listing all folders in a wallet can be done by:
+
+#+begin_src elisp
+  (auth-source-search :list t :folder "" :wallet "kdewallet" :type 'kwallet)
+#+end_src
+
+And to list labels (and/or user and hostnames in a specific folder:
+
+#+begin_src elisp
+  (auth-source-search :list t :folder "SolidLuks" :wallet "kdewallet" :type 'kwallet)
 #+end_src
 
 ** Configuration

--- a/README.org
+++ b/README.org
@@ -18,6 +18,46 @@
 
    To enable the auth source, use ~(auth-source-kwallet-enable)~, like in the example above with use-package.
 
+** Using auth-source-search
+After loading the library, enabling it, and configuring, ~auth-source-search~ can be used to query kwallet.
+
+To query the secret of "ada@example.com" using the default wallet and folder:
+
+#+begin_src elisp
+  (auth-source-search :user "ada" :host "example.com" :type 'kwallet)
+#+end_src
+
+To use a different wallet and folder than the default one:
+
+#+begin_src elisp
+  (auth-source-search :user "ada" :host "example.com"
+                      :folder "OtherHosts"
+                      :wallet "kdewallet2"
+                      :type 'kwallet)
+#+end_src
+
+Kwallet stores secrets from different applications, and sometimes they do not use username and hostname to search for it. Use ~:label~ in this cases:
+
+#+begin_src elisp
+  (auth-source-search :label "search-key-name" :type 'kwallet)
+#+end_src
+
+For example, a LUKS disk password can be searched by changing the folder:
+
+#+begin_src elisp
+  (auth-source-search :label "f1bc3d13-7e64-4bcf-8abe-5f155f68e752"
+                      :folder "SolidLuks"
+                      :type 'kwallet)
+#+end_src
+
+Also, Network Managent secrets can be stored on kwallet and retrieved with auth-source:
+
+#+begin_src elisp
+  (auth-source-search :label "{0aeca2dd-549f-4095-9001-96dd52d50813};802-11-wireless-security"
+                      :folder "Network Management"
+                      :type 'kwallet)
+#+end_src
+
 ** Configuration
 
    The following parameters can be customized:

--- a/auth-source-kwallet.el
+++ b/auth-source-kwallet.el
@@ -126,11 +126,13 @@ ENTRY is as required by auth-source."
 (defun auth-source-kwallet-enable ()
   "Enable the kwallet auth source."
 
-  (advice-add 'auth-source-backend-parse
-              :before-until
-              #'auth-source-kwallet--kwallet-backend-parse)
+  ;; (advice-add 'auth-source-backend-parse
+  ;;             :before-until
+  ;;             #'auth-source-kwallet--kwallet-backend-parse)
   (add-to-list 'auth-sources 'kwallet)
   (auth-source-forget-all-cached))
+
+(add-hook 'auth-source-backend-parser-functions #'auth-source-kwallet--kwallet-backend-parse)
 
 (provide 'auth-source-kwallet)
 

--- a/auth-source-kwallet.el
+++ b/auth-source-kwallet.el
@@ -66,15 +66,18 @@ wallet."
 LABEL is the label to search in kwallet.
 FOLDER and WALLET are optional.  If not provided, `auth-source-kwallet-folder'
 and `auth-source-kwallet-wallet' are used respectively."
-  (json-parse-string
-   (shell-command-to-string (format "%s %s -f %s -r %s"
-                                    auth-source-kwallet-executable
-                                    (shell-quote-argument
-                                     (or wallet auth-source-kwallet-wallet))
-                                    (shell-quote-argument
-                                     (or folder auth-source-kwallet-folder))
-                                    (shell-quote-argument label)))
-   :object-type 'alist))
+  (let ((str-result (string-trim
+                     (shell-command-to-string (format "%s %s -f %s -r %s"
+                                                      auth-source-kwallet-executable
+                                                      (shell-quote-argument
+                                                       (or wallet auth-source-kwallet-wallet))
+                                                      (shell-quote-argument
+                                                       (or folder auth-source-kwallet-folder))
+                                                      (shell-quote-argument label))))))
+    (condition-case nil
+        (json-parse-string str-result :object-type 'alist)
+      (json-parse-error str-result)
+      (json-trailing-content str-result))))
 
 (cl-defun auth-source-kwallet--kwallet-search (&rest spec
                                                 &key _backend _type host user _port

--- a/auth-source-kwallet.el
+++ b/auth-source-kwallet.el
@@ -46,18 +46,31 @@
   :group 'auth-source-kwallet)
 
 (cl-defun auth-source-kwallet--kwallet-search (&rest spec
-                                                     &key _backend _type host user _port
-                                                     &allow-other-keys)
-  "Searche KWallet for the specified user and host.
-SPEC, BACKEND, TYPE, HOST, USER and PORT are as required by auth-source."
+                                                &key _backend _type host user _port
+                                                folder wallet label
+                                                &allow-other-keys)
+  "Search KWallet for the specified user and host.
+SPEC, BACKEND, TYPE, HOST, USER and PORT are as required by auth-source.
+Other key parameters are FOLDER, WALLET, and LABEL.  These are kwallet specific
+parameters.
+
+If FOLDER is not provided, then `auth-source-kwallet-folder' is used.
+Similarly, if WALLET is nil or not provided, `auth-source-kwallet-wallet' is
+used.
+
+HOST and USER are used to compose the kwallet search query.  If LABEL is
+provided, it is used instead.
+"
   (if (executable-find auth-source-kwallet-executable)
       (let ((got-secret (string-trim
                          (shell-command-to-string
                           (format "%s %s -f %s -r %s"
                                   auth-source-kwallet-executable
-                                  auth-source-kwallet-wallet
-                                  auth-source-kwallet-folder
-                                  (shell-quote-argument (concat user auth-source-kwallet-key-separator host)))))))
+                                  (if wallet wallet auth-source-kwallet-wallet)
+                                  (if folder folder auth-source-kwallet-folder)
+                                  (shell-quote-argument
+                                   (if label label
+                                     (concat user auth-source-kwallet-key-separator host))))))))
         (list (list :user user
                     :secret got-secret)))
     ;; If not executable was found, return nil and show a warning

--- a/auth-source-kwallet.el
+++ b/auth-source-kwallet.el
@@ -59,8 +59,7 @@ Similarly, if WALLET is nil or not provided, `auth-source-kwallet-wallet' is
 used.
 
 HOST and USER are used to compose the kwallet search query.  If LABEL is
-provided, it is used instead.
-"
+provided, it is used instead."
   (if (executable-find auth-source-kwallet-executable)
       (let ((got-secret (string-trim
                          (shell-command-to-string
@@ -74,7 +73,8 @@ provided, it is used instead.
         (list (list :user user
                     :secret got-secret)))
     ;; If not executable was found, return nil and show a warning
-    (warn (format "`auth-source-kwallet': Could not find executable '%s' to query KWallet"))))
+    (warn (format "`auth-source-kwallet': Could not find executable '%s' to query KWallet"
+                  auth-source-kwallet-executable))))
 
 (defun auth-source-kwallet--kwallet-backend-parse (entry)
   "Parse the entry to check if this is a kwallet entry.

--- a/auth-source-kwallet.el
+++ b/auth-source-kwallet.el
@@ -65,8 +65,10 @@ provided, it is used instead."
                          (shell-command-to-string
                           (format "%s %s -f %s -r %s"
                                   auth-source-kwallet-executable
-                                  (if wallet wallet auth-source-kwallet-wallet)
-                                  (if folder folder auth-source-kwallet-folder)
+                                  (shell-quote-argument
+                                   (if wallet wallet auth-source-kwallet-wallet))
+                                  (shell-quote-argument
+                                   (if folder folder auth-source-kwallet-folder))
                                   (shell-quote-argument
                                    (if label label
                                      (concat user auth-source-kwallet-key-separator host))))))))

--- a/auth-source-kwallet.el
+++ b/auth-source-kwallet.el
@@ -184,10 +184,14 @@ ENTRY is as required by auth-source."
   ;; (advice-add 'auth-source-backend-parse
   ;;             :before-until
   ;;             #'auth-source-kwallet--kwallet-backend-parse)
+  ;;
+  ;; In auth-source.el, their authors add a new parser by using the
+  ;; `auth-source-backend-parser-functions' hook, instead of advising the
+  ;; `auth-source-backend-parse'.  Just to be sure, we do the same as them :).
+  
+  (add-hook 'auth-source-backend-parser-functions #'auth-source-kwallet--kwallet-backend-parse)
   (add-to-list 'auth-sources 'kwallet)
   (auth-source-forget-all-cached))
-
-(add-hook 'auth-source-backend-parser-functions #'auth-source-kwallet--kwallet-backend-parse)
 
 (provide 'auth-source-kwallet)
 


### PR DESCRIPTION
Hi! :wave: 

I made some modifications to provide support for listing (kwallet-query `-l` argument) and to search by label instead of user@host.  The label parameter is useful for searching encrypted partition passwords (such as LUKS), WiFi (or network) passwords,  or any other data in kwallet.

With this version, after evaluating `(auth-source-kwallet-enable)`, it is posible to eval the following:
```elisp
  ;; Get a specific partition password:
  (auth-source-search :wallet "Another_wallet_intead_the_default" 
                      :folder "SolidLuks" 
                      ;; a partition ID:
                      :label "6c4c880d-98aa-452a-a1a3-13e73f044d3a")

  ;; Get a list of entries in SolidLuks folders:
  (auth-source-search :folder "SolidLuks" :list t)
```

Also I updated the README, fixed what flycheck (and checkdoc) suggest, and used the hook `auth-source-backend-parser-functions` (instead of advising) as the auth-source authors used. 

Also, kwallet-query returns a JSON which is now parsed by using `json-parse-string` to return an Elisp alist instead of a string. However, this requires Emacs version >=27.1, because these JSON parsing functions was included in those releases.
Despite this new Emacs version requirement, ¿do you want to merge this pull request?

Cheers!